### PR TITLE
feat: remove HTTP from discovery node

### DIFF
--- a/nodes/wot-discovery.html
+++ b/nodes/wot-discovery.html
@@ -11,9 +11,6 @@
             coapIPv4Address: { value: "all" },
             useMqtt: { value: "" },
             mqttBrokerAddress: { value: "" },
-            useHttp: { value: true },
-            httpUseIPv6: { value: true },
-            httpUseIPv4: { value: false },
             timeoutRemoval: { value: true },
             removalTime: { value: 15 },
             msgOrContext: { value: "msg" },
@@ -266,39 +263,6 @@
             id="node-input-mqttBrokerAddress"
             placeholder="mqtt://"
         />
-    </div>
-
-    <div class="form-row">
-        <input
-            type="checkbox"
-            id="node-input-useHttp"
-            style="display: inline-block; width: auto; vertical-align: top;"
-        />
-        <label for="node-input-useHttp" style="width: auto">
-            Use HTTP for discovery
-        </label>
-    </div>
-
-    <div class="form-row">
-        <input
-            type="checkbox"
-            id="node-input-httpUseIPv6"
-            style="display: inline-block; width: auto; vertical-align: top;"
-        />
-        <label for="node-input-httpUseIPv6" style="width: auto">
-            Use IPv6 multicast
-        </label>
-    </div>
-
-    <div class="form-row">
-        <input
-            type="checkbox"
-            id="node-input-httpUseIPv4"
-            style="display: inline-block; width: auto; vertical-align: top;"
-        />
-        <label for="node-input-httpUseIPv4" style="width: auto">
-            Use IPv4 multicast
-        </label>
     </div>
 </script>
 

--- a/nodes/wot-discovery.js
+++ b/nodes/wot-discovery.js
@@ -18,7 +18,7 @@ module.exports = function (RED) {
 
         const timeouts = {};
 
-        // TODO: Add Implementations for MQTT and HTTP
+        // TODO: Add Implementations for MQTT
 
         if (config.useCoap) {
             coapAddresses = _getCoapAddresses(config);


### PR DESCRIPTION
As HTTP does not support multicast discovery (as it uses the connection based TCP) it probably does not make much sense to include it in the discovery node. Maybe we should add a note that for this kind of direct discovery an HTTP node should be used?